### PR TITLE
Fix non-forestry honey used to craft Mega apiary

### DIFF
--- a/src/main/java/kubatech/loaders/RecipeLoader.java
+++ b/src/main/java/kubatech/loaders/RecipeLoader.java
@@ -96,7 +96,7 @@ public class RecipeLoader {
                     },
                     new FluidStack[] {
                         FluidRegistry.getFluidStack("molten.indalloy140", 28800),
-                        FluidRegistry.getFluidStack("honey", 20000)
+                        FluidRegistry.getFluidStack("for.honey", 20000)
                     },
                     ExtremeIndustrialApiary.get(1),
                     6000,


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12005