### PR TITLE
Calculate used power based on how many bees are in the mApiary

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
@@ -450,7 +450,6 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
 
     @Override
     public boolean checkRecipe(ItemStack aStack) {
-        int workingBees = 0;
         updateMaxSlots();
         if (mPrimaryMode < 2) {
             if (mPrimaryMode == 0 && mStorage.size() < mMaxSlots) {
@@ -518,10 +517,9 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
                     for (int i = 0, mStorageSize = Math.min(mStorage.size(), mMaxSlots); i < mStorageSize; i++) {
                         BeeSimulator beeSimulator = mStorage.get(i);
                         stacks.addAll(beeSimulator.getDrops(64_00d * boosted));
-                        workingBees++;
                     }
 
-                    this.lEUt = -GT_Values.VP[6] * workingBees;
+                    this.lEUt = -GT_Values.VP[6] * mStorage.size();
                     this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
                     this.mEfficiencyIncrease = 10000;
                     this.mMaxProgresstime = 100;

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
@@ -450,6 +450,7 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
 
     @Override
     public boolean checkRecipe(ItemStack aStack) {
+        int workingBees = 0;
         updateMaxSlots();
         if (mPrimaryMode < 2) {
             if (mPrimaryMode == 0 && mStorage.size() < mMaxSlots) {
@@ -517,9 +518,10 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
                     for (int i = 0, mStorageSize = Math.min(mStorage.size(), mMaxSlots); i < mStorageSize; i++) {
                         BeeSimulator beeSimulator = mStorage.get(i);
                         stacks.addAll(beeSimulator.getDrops(64_00d * boosted));
+                        workingBees++;
                     }
 
-                    this.lEUt = -(int) ((double) GT_Values.V[6] * (double) mMaxSlots * 0.99d);
+                    this.lEUt = -GT_Values.VP[6] * workingBees;
                     this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
                     this.mEfficiencyIncrease = 10000;
                     this.mMaxProgresstime = 100;


### PR DESCRIPTION
- Instead of max slots, it will calculate the consumed power based on bees
- Replaced the calculation of using 99% of an an amp with the array that consumes the recipe amps. (e.g. 1 bee will consume 30.720 EU/t