### PR TITLE
Changed EEC tooltip's glass specification

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
@@ -274,7 +274,7 @@ public class GT_MetaTileEntity_ExtremeExterminationChamber
             .beginStructureBlock(5, 7, 5, true)
             .addController("Front Bottom Center")
             .addCasingInfoMin("Solid Steel Machine Casing", 35, false)
-            .addOtherStructurePart("Tiered Glass", "Side walls without edges or corners")
+            .addOtherStructurePart("Tiered (HV+) Glass", "Side walls without edges or corners")
             .addStructureInfo("The glass tier limits the Energy Hatch tier")
             .addOtherStructurePart("Steel Frame Box", "All vertical edges without corners")
             .addOtherStructurePart("Diamond spikes", "Inside second layer")

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
@@ -274,7 +274,7 @@ public class GT_MetaTileEntity_ExtremeExterminationChamber
             .beginStructureBlock(5, 7, 5, true)
             .addController("Front Bottom Center")
             .addCasingInfoMin("Solid Steel Machine Casing", 35, false)
-            .addOtherStructurePart("Borosilicate Glass", "Side walls without edges or corners")
+            .addOtherStructurePart("Tiered Glass", "Side walls without edges or corners")
             .addStructureInfo("The glass tier limits the Energy Hatch tier")
             .addOtherStructurePart("Steel Frame Box", "All vertical edges without corners")
             .addOtherStructurePart("Diamond spikes", "Inside second layer")


### PR DESCRIPTION
The EEC takes Reinforced Glass, something I was surprised to find out because the tooltip explicitly specifies Borosilicate. I imagine this means it works with other non-Borosilicate glasses (the Botania duo, Th-Y glass...), so the tooltip could be more general.

If this doesn't accurately capture the requirement somehow maybe we could settle on something in the middle, I just want it to be able to inform that the multi takes other glass types (whichever ones it actually can).