### PR TITLE
Fix some UX and voiding issues with EIG and MIA

### DIFF
--- a/src/main/java/kubatech/api/implementations/KubaTechGTMultiBlockBase.java
+++ b/src/main/java/kubatech/api/implementations/KubaTechGTMultiBlockBase.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -49,6 +48,7 @@ import com.gtnewhorizons.modularui.common.internal.wrapper.ModularUIContainer;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
 import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_ExtendedPowerMultiBlockBase;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_OutputBus;
@@ -202,7 +202,8 @@ public abstract class KubaTechGTMultiBlockBase<T extends GT_MetaTileEntity_Exten
         return tryOutputAll(list, mappingFunction, false);
     }
 
-    protected boolean tryOutputAll(List<?> list, Function<Object, List<ItemStack>> mappingFunction, boolean dropExtrasInWorld) {
+    protected boolean tryOutputAll(List<?> list, Function<Object, List<ItemStack>> mappingFunction,
+        boolean dropExtrasInWorld) {
         if (list == null || list.isEmpty() || mappingFunction == null) return false;
         int emptySlots = 0;
         boolean ignoreEmptiness = false;
@@ -245,7 +246,8 @@ public abstract class KubaTechGTMultiBlockBase<T extends GT_MetaTileEntity_Exten
         IHasWorldObjectAndCoords te = getBaseMetaTileEntity();
         for (ItemStack stack : stacks) {
             EntityItem item = new EntityItem(te.getWorld(), te.getXCoord(), te.getYCoord(), te.getZCoord(), stack);
-            te.getWorld().spawnEntityInWorld(item);
+            te.getWorld()
+                .spawnEntityInWorld(item);
         }
     }
 

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeIndustrialGreenhouse.java
@@ -820,12 +820,14 @@ public class GT_MetaTileEntity_ExtremeIndustrialGreenhouse
                 if (clickData.shift) {
                     if (player.inventory.addItemStackToInventory(removed.input)) {
                         player.inventoryContainer.detectAndSendChanges();
-                        return;
+                    } else {
+                        mStorage.add(realID, removed);
                     }
+                    return;
                 }
                 if (clickData.ctrl) {
                     if (!addOutput(removed.input)) {
-                        mStorage.add(removed);
+                        mStorage.add(realID, removed);
                         GT_Utility.sendChatToPlayer(player, "No space to eject crop to!");
                         return;
                     }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeIndustrialGreenhouse.java
@@ -229,7 +229,7 @@ public class GT_MetaTileEntity_ExtremeIndustrialGreenhouse
     @Override
     public void onRemoval() {
         super.onRemoval();
-        if (getBaseMetaTileEntity().isServerSide()) tryOutputAll(mStorage, this::getOutputsFromInternalSlots);
+        if (getBaseMetaTileEntity().isServerSide()) tryOutputAll(mStorage, this::getOutputsFromInternalSlots, true);
     }
 
     @Override

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
@@ -257,7 +257,7 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
     public void onRemoval() {
         super.onRemoval();
         if (getBaseMetaTileEntity().isServerSide())
-            tryOutputAll(mStorage, s -> Collections.singletonList(((BeeSimulator) s).queenStack));
+            tryOutputAll(mStorage, s -> Collections.singletonList(((BeeSimulator) s).queenStack), true);
     }
 
     private boolean isCacheDirty = true;

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
@@ -940,12 +940,14 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
                 if (clickData.shift) {
                     if (player.inventory.addItemStackToInventory(removed.queenStack)) {
                         player.inventoryContainer.detectAndSendChanges();
-                        return;
+                    } else {
+                        mStorage.add(realID, removed);
                     }
+                    return;
                 }
                 if (clickData.ctrl) {
                     if (!addOutput(removed.queenStack)) {
-                        mStorage.add(removed);
+                        mStorage.add(realID, removed);
                         GT_Utility.sendChatToPlayer(player, "No space to eject queen!");
                         return;
                     }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_MegaIndustrialApiary.java
@@ -943,17 +943,20 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
                         return;
                     }
                 }
-                if (clickData.mouseButton == 1) {
-                    if (player.inventory.getItemStack() == null) {
-                        player.inventory.setItemStack(removed.queenStack);
-                        ((EntityPlayerMP) player).isChangingQuantityOnly = false;
-                        ((EntityPlayerMP) player).updateHeldItem();
+                if (clickData.ctrl) {
+                    if (!addOutput(removed.queenStack)) {
+                        mStorage.add(removed);
+                        GT_Utility.sendChatToPlayer(player, "No space to eject queen!");
                         return;
                     }
+                    GT_Utility.sendChatToPlayer(player, "Queen ejected !");
+                    return;
                 }
-
-                addOutput(removed.queenStack);
-                GT_Utility.sendChatToPlayer(player, "Queen ejected !");
+                if (player.inventory.getItemStack() == null) {
+                    player.inventory.setItemStack(removed.queenStack);
+                    ((EntityPlayerMP) player).isChangingQuantityOnly = false;
+                    ((EntityPlayerMP) player).updateHeldItem();
+                }
             })
                 .setBackground(
                     () -> new IDrawable[] { getBaseMetaTileEntity().getGUITextureSet()
@@ -970,9 +973,9 @@ public class GT_MetaTileEntity_MegaIndustrialApiary
                         EnumChatFormatting.DARK_PURPLE + "There are "
                             + drawables.get(finalID).count
                             + " identical slots",
-                        EnumChatFormatting.GRAY + "Left click to eject into input bus",
-                        EnumChatFormatting.GRAY + "Right click to get into mouse",
+                        EnumChatFormatting.GRAY + "Click to get into mouse",
                         EnumChatFormatting.GRAY + "Shift click to get into inventory",
+                        EnumChatFormatting.GRAY + "Control click to eject into output bus",
                         EnumChatFormatting.GRAY + "Click with other queen in mouse to replace");
                     return Collections.emptyList();
                 })


### PR DESCRIPTION
The behavior of the slots in the EIG and MAI is extremely counterintuitive, in that left-clicking the item would not pick it up into your mouse like every other inventory in the game. This pr changes the behavior to pick up the item on left or right-click, and send it to the output bus on control-click.

Also fixes a couple voiding bugs related to the EIG and MIA:
- Attempting to send items to a full output bus voids the items (it now refuses to do so and sends a chat message)
- Breaking the controller voids all contained items that cannot fit in the output bus (it now drops excess items in world when breaking the controller)