### PR TITLE
Fix EEC WorldClient leak

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@
  */
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.72:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.80:dev')
     api("com.github.GTNewHorizons:EnderCore:0.2.18:dev")
     api("com.github.GTNewHorizons:EnderIO:2.5.3:dev")
     api("com.github.GTNewHorizons:ForestryMC:4.6.14:dev")

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeExterminationChamber.java
@@ -160,6 +160,11 @@ public class GT_MetaTileEntity_ExtremeExterminationChamber
         }
     }
 
+    @Override
+    public void onUnload() {
+        if (LoaderReference.BloodMagic) MinecraftForge.EVENT_BUS.unregister(this);
+    }
+
     private static final String WellOfSufferingRitualName = "AW013Suffering";
 
     private static final Item poweredSpawnerItem = Item.getItemFromBlock(EnderIO.blockPoweredSpawner);


### PR DESCRIPTION
Fixes a memory leak that happens when the tile-entity cant be garbage collected because its still registered in the event bus thus keeping the world contained in the tile-entity alive. This depends on the newly added method `onUnload()` that was added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2366