### PR TITLE
Fix Soldering Iron unable to set redstone output strength for the EEC.

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/GT_MetaTileEntity_ExtremeEntityCrusher.java
@@ -415,10 +415,11 @@ public class GT_MetaTileEntity_ExtremeEntityCrusher
     @Override
     public boolean onSolderingToolRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
         float aX, float aY, float aZ) {
-        if (super.onSolderingToolRightClick(side, wrenchingSide, aPlayer, aX, aY, aZ)) return true;
-        mAnimationEnabled = !mAnimationEnabled;
-        GT_Utility.sendChatToPlayer(aPlayer, "Animations are " + (mAnimationEnabled ? "enabled" : "disabled"));
-        return true;
+        if (wrenchingSide == getBaseMetaTileEntity().getFrontFacing()) {
+            mAnimationEnabled = !mAnimationEnabled;
+            GT_Utility.sendChatToPlayer(aPlayer, "Animations are " + (mAnimationEnabled ? "enabled" : "disabled"));
+            return true;
+        } else return super.onSolderingToolRightClick(side, wrenchingSide, aPlayer, aX, aY, aZ);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Same change as https://github.com/GTNewHorizons/GTplusplus/pull/819 for GT++.

Right-clicking the front face of the EEC toggles animations, right-clicking any other face toggles redstone output strength.