### PR TITLE
Chaos recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,20 +35,20 @@
  */
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.70:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.114:dev')
     {
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }
-    api("com.github.GTNewHorizons:EnderCore:0.3.1:dev")
-    api("com.github.GTNewHorizons:EnderIO:2.6.4:dev")
-    api("com.github.GTNewHorizons:ForestryMC:4.8.2:dev")
-    api("com.github.GTNewHorizons:ModularUI:1.1.26:dev")
-    api("com.github.GTNewHorizons:Mobs-Info:0.2.3-GTNH:dev")
-    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.8.0-GTNH:dev")
+    api("com.github.GTNewHorizons:EnderCore:0.4.6:dev")
+    api("com.github.GTNewHorizons:EnderIO:2.7.1:dev")
+    api("com.github.GTNewHorizons:ForestryMC:4.8.7:dev")
+    api("com.github.GTNewHorizons:ModularUI:1.1.42:dev")
+    api("com.github.GTNewHorizons:Mobs-Info:0.2.5-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.8.1-GTNH:dev")
     //compileOnly("curse.maven:extrautilities-225561:2264384") {
     //    transitive = false
     //}
-    compileOnly("com.github.GTNewHorizons:GTplusplus:1.11.25:dev")
+    compileOnly("com.github.GTNewHorizons:GTplusplus:1.11.42:dev")
     {
         transitive = false
     }
@@ -64,15 +64,15 @@ dependencies {
     {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:bartworks:0.9.10:dev")
+    compileOnly("com.github.GTNewHorizons:bartworks:0.9.17:dev")
     {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.27:dev")
+    compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.42:dev")
     {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.6.0-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.6.1-GTNH:dev")
     {
         transitive = false
     }
@@ -86,17 +86,17 @@ dependencies {
     */
 
     // For testing
-    //runtimeOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.6.0-GTNH:dev")
-    //runtimeOnly("com.github.GTNewHorizons:GTplusplus:1.11.25:dev")
+    //runtimeOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.6.1-GTNH:dev")
+    //runtimeOnly("com.github.GTNewHorizons:GTplusplus:1.11.42:dev")
     //runtimeOnly("com.github.GTNewHorizons:harvestcraft:1.1.10-GTNH:dev")
-    //runtimeOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.27:dev")
+    //runtimeOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.42:dev")
     //runtimeOnly("com.github.GTNewHorizons:OpenBlocks:1.9.1-GTNH:dev")
-    //runtimeOnly("com.github.GTNewHorizons:bartworks:0.9.10:dev")
+    //runtimeOnly("com.github.GTNewHorizons:bartworks:0.9.17:dev")
     //runtimeOnly("com.github.GTNewHorizons:CraftTweaker:3.3.1:dev")
     //api("com.github.GTNewHorizons:SpecialMobs:3.5.0:dev")
-    //api("com.github.GTNewHorizons:twilightforest:2.5.12:dev")
+    //api("com.github.GTNewHorizons:twilightforest:2.5.19:dev")
     //api("com.github.GTNewHorizons:EnderZoo:1.1.0:dev")
-    runtimeOnly("com.github.GTNewHorizons:Draconic-Evolution:1.3.1-GTNH:dev")
+    runtimeOnly("com.github.GTNewHorizons:Draconic-Evolution:1.3.2-GTNH:dev")
     //runtimeOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     //runtimeOnly("com.github.GTNewHorizons:BloodMagic:1.5.1:dev")
     //api("curse.maven:witchery-69673:2234410")

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -279,7 +279,7 @@ public class DEFCRecipes {
                 GT_ModHandler.getModItem("Thaumcraft", "blockCrystal", 8, 7),
                 GT_ModHandler.getModItem("GalacticraftAmunRa", "item.baseItem", 32, 26),
                 GT_ModHandler.getModItem("gregtech", "gt.metaitem.02", 16, 30209),
-                GT_ModHandler.getModItem("harvestcraft", "chaoscookieItem", 9),
+                GT_ModHandler.getModItem("HardcoreEnderExpansion", "curse", 9, 262),
                 GT_ModHandler.getModItem("EnderIO", "bucketVapor_of_levity", 1))
             .fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(20737))
             .itemOutputs(GT_ModHandler.getModItem("DraconicEvolution", "chaosShard", 1))
@@ -299,12 +299,12 @@ public class DEFCRecipes {
                 GT_ModHandler.getModItem("Botania", "laputaShard", 1, 0),
                 GT_ModHandler.getModItem("MagicBees", "propolis", 32, 6),
                 GT_ModHandler.getModItem("dreamcraft", "item.MysteriousCrystalGemExquisite", 32),
-                GT_ModHandler.getModItem("harvestcraft", "dragonfruitItem", 32),
+                GT_ModHandler.getModItem("eternalsingularity", "combined_singularity", 7, 1),
                 GT_ModHandler.getModItem("AWWayofTime", "enhancedFillingAgent", 8))
-            .fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(20737))
-            .itemOutputs(GT_ModHandler.getModItem("DraconicEvolution", "chaosFragment", 8, 0))
+            .fluidInputs(MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(20737))
+            .itemOutputs(GT_ModHandler.getModItem("DraconicEvolution", "chaosFragment", 7, 0))
             .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.glass"), 1152))
-            .eut(24_000_000)
+            .eut(536_870_912)
             .duration(6200)
             .specialValue(4)
             .addTo(fusionCraftingRecipes)

--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -268,6 +268,48 @@ public class DEFCRecipes {
             .addTo(fusionCraftingRecipes)
             .forEach(DEFCRecipes::addOldHiddenRecipe);
 
+        // Chaos Shards
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_ModHandler.getModItem("AWWayofTime", "energyBazookaThirdTier", 0),
+                new ItemStack(Blocks.dragon_egg, 8),
+                GT_ModHandler.getModItem("Avaritia", "Resource", 64, 8),
+                GT_ModHandler.getModItem("HardcoreEnderExpansion", "transference_gem", 1),
+                GT_ModHandler.getModItem("Thaumcraft", "blockCrystal", 8, 7),
+                GT_ModHandler.getModItem("GalacticraftAmunRa", "item.baseItem", 32, 26),
+                GT_ModHandler.getModItem("gregtech", "gt.metaitem.02", 16, 30209),
+                GT_ModHandler.getModItem("harvestcraft", "chaoscookieItem", 9),
+                GT_ModHandler.getModItem("EnderIO", "bucketVapor_of_levity", 1))
+            .fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(20737))
+            .itemOutputs(GT_ModHandler.getModItem("DraconicEvolution", "chaosShard", 1))
+            .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.iron"), 432))
+            .eut(24_000_000)
+            .duration(3200)
+            .specialValue(5)
+            .addTo(fusionCraftingRecipes)
+            .forEach(DEFCRecipes::addOldHiddenRecipe);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_ModHandler.getModItem("witchery", "infinityegg", 0),
+                GT_ModHandler.getModItem("gadomancy", "ItemElement", 1, 0),
+                GT_ModHandler.getModItem("miscutils", "blockBlockDragonblood", 8),
+                GT_ModHandler.getModItem("DraconicEvolution", "draconium", 8, 1),
+                GT_ModHandler.getModItem("Botania", "laputaShard", 1, 0),
+                GT_ModHandler.getModItem("MagicBees", "propolis", 32, 6),
+                GT_ModHandler.getModItem("dreamcraft", "item.MysteriousCrystalGemExquisite", 32),
+                GT_ModHandler.getModItem("harvestcraft", "dragonfruitItem", 32),
+                GT_ModHandler.getModItem("AWWayofTime", "enhancedFillingAgent", 8))
+            .fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(20737))
+            .itemOutputs(GT_ModHandler.getModItem("DraconicEvolution", "chaosFragment", 8, 0))
+            .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.glass"), 1152))
+            .eut(24_000_000)
+            .duration(6200)
+            .specialValue(4)
+            .addTo(fusionCraftingRecipes)
+            .forEach(DEFCRecipes::addOldHiddenRecipe);
+
         // Dragon Blood
         if (LoaderReference.GTPlusPlus) {
 


### PR DESCRIPTION
-Added 2 chaos shards recipe, one costly but that can be done without tier 5 coils, and one "eassy" but with tier 5 coils, the use are basically for people that want many chaos shards and whant to invest in chaotic coils, and for people who are doing special runs, and can´t kill the chaos dragon

At the moment the 2 recipes work fine, but I think the voltage tier should be tweaked ( for example so the players that are doing the expert recipe for the special run can only craft it if they want the shards for stargate and have to use the maximum tier)

![image](https://github.com/GTNewHorizons/KubaTech/assets/45178400/04fe6921-f02f-44ce-a88d-305b8940de66)

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14945