### PR TITLE
Add improved Dragonblood DEFC recipes with comb

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
 }
 
 

--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -26,7 +26,9 @@ import gregtech.api.recipe.RecipeMapBuilder;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_Utility;
 import gregtech.nei.formatter.SimpleSpecialValueFormatter;
+import gtPlusPlus.xmod.forestry.bees.handler.GTPP_CombType;
 import kubatech.Tags;
 import kubatech.api.LoaderReference;
 
@@ -274,7 +276,8 @@ public class DEFCRecipes {
             GT_Values.RA.stdBuilder()
                 .itemInputs(
                     new ItemStack(Blocks.dragon_egg, 0),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64))
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GT_Utility.getIntegratedCircuit(1))
                 .fluidInputs(Materials.Radon.getPlasma(144))
                 .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 288))
                 .eut(1_966_080)
@@ -286,11 +289,38 @@ public class DEFCRecipes {
             GT_Values.RA.stdBuilder()
                 .itemInputs(
                     GT_ModHandler.getModItem("witchery", "infinityegg", 0),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64))
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GT_Utility.getIntegratedCircuit(1))
                 .fluidInputs(Materials.Radon.getPlasma(72))
                 .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
                 .eut(1_966_080)
                 .duration(3600)
+                .specialValue(3)
+                .noOptimize()
+                .addTo(fusionCraftingRecipes);
+
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    new ItemStack(Blocks.dragon_egg, 0),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GTPP_CombType.DRAGONBLOOD.getStackForType(1))
+                .fluidInputs(Materials.Radon.getPlasma(216))
+                .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
+                .eut(1_966_080)
+                .duration(2800)
+                .specialValue(3)
+                .noOptimize()
+                .addTo(fusionCraftingRecipes);
+
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_ModHandler.getModItem("witchery", "infinityegg", 0),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GTPP_CombType.DRAGONBLOOD.getStackForType(1))
+                .fluidInputs(Materials.Radon.getPlasma(108))
+                .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 648))
+                .eut(1_966_080)
+                .duration(2400)
                 .specialValue(3)
                 .noOptimize()
                 .addTo(fusionCraftingRecipes);


### PR DESCRIPTION
Adds new recipes for Dragonblood in the DEFC with Dragon Blood Combs, giving those combs a more viable use.

Gives both normal and infinity egg Dragonblood recipes a 1.5x yield and 1.5x shorter time when Dragon Blood Combs are used.

Balancing and (most of) the code from @GDCloudstrike 